### PR TITLE
removed babelrc from files published to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 demo
+.babelrc


### PR DESCRIPTION
not necessary to publish babelrc if it's getting built with babel